### PR TITLE
Feat : [Fix] lazyinitializationexception 해결

### DIFF
--- a/src/main/java/com/bob/mate/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/bob/mate/domain/user/entity/UserProfile.java
@@ -9,6 +9,7 @@ import lombok.ToString;
 import javax.persistence.*;
 
 import static javax.persistence.EnumType.STRING;
+import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -35,7 +36,7 @@ public class UserProfile {
     @Enumerated(STRING)
     private Gender gender;
 
-    @OneToOne(mappedBy = "userProfile")
+    @OneToOne(mappedBy = "userProfile", fetch = LAZY)
     private User user;
 
     private Integer age;

--- a/src/main/java/com/bob/mate/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/bob/mate/domain/user/repository/UserRepository.java
@@ -3,7 +3,7 @@ package com.bob.mate.domain.user.repository;
 import com.bob.mate.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User,Long> {
+public interface UserRepository extends JpaRepository<User,Long>, UserRepositoryCustom {
 
-    User findByEmail(String email);
+//    User findByEmail(String email);
 }

--- a/src/main/java/com/bob/mate/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/bob/mate/domain/user/repository/UserRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.bob.mate.domain.user.repository;
+
+import com.bob.mate.domain.user.entity.User;
+
+public interface UserRepositoryCustom {
+
+    User findByEmail(String email);
+}

--- a/src/main/java/com/bob/mate/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/bob/mate/domain/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.bob.mate.domain.user.repository;
+
+import com.bob.mate.domain.user.entity.QUser;
+import com.bob.mate.domain.user.entity.QUserProfile;
+import com.bob.mate.domain.user.entity.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.bob.mate.domain.user.entity.QUser.*;
+import static com.bob.mate.domain.user.entity.QUserProfile.*;
+
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+
+    /**
+     * UserEmail 조회
+     * User + UserProfile fetch join 한방 쿼리
+     */
+    @Override
+    public User findByEmail(String email) {
+        return queryFactory
+                .selectFrom(user)
+                .innerJoin(user.userProfile, userProfile)
+                .fetchJoin()
+                .where(user.email.eq(email))
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/bob/mate/global/config/PrincipalOauth2UserService.java
+++ b/src/main/java/com/bob/mate/global/config/PrincipalOauth2UserService.java
@@ -18,12 +18,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
 
     @Override
-    @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         log.info("ClientRegistration = {}", userRequest.getClientRegistration());
         log.info("AccessToken = {}", userRequest.getAccessToken().getTokenValue());
@@ -59,7 +59,7 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
 
             log.info("userEntity = {}", userEntity);
         }
-            return new PrincipalOauth2Details(userEntity, oAuth2User.getAttributes());
+        return new PrincipalOauth2Details(userEntity, oAuth2User.getAttributes());
     }
 }
 

--- a/src/main/java/com/bob/mate/global/config/provider/KakaoUserInfo.java
+++ b/src/main/java/com/bob/mate/global/config/provider/KakaoUserInfo.java
@@ -10,14 +10,7 @@ public class KakaoUserInfo implements Oauth2UserInfo {
     private Map<String, Object> attributes;
 
 
-    public Map<String, Object> getKakaoAccount(){
-        return(Map<String, Object>) attributes.get("kakao_account");
-    }
 
-    public Map<String, Object> getProfile(){
-        Map<String, Object> kakaoAccount = getKakaoAccount();
-        return (Map<String, Object>) kakaoAccount.get("profile");
-    }
 
 
     public KakaoUserInfo(Map<String, Object> attributes) {
@@ -36,25 +29,30 @@ public class KakaoUserInfo implements Oauth2UserInfo {
 
     @Override
     public String getEmail() {
-        Map<String, Object> kakaoAccount = getKakaoAccount();
-        return (String) kakaoAccount.get("email");
+        return (String) getKakaoAccount().get("email");
     }
 
     @Override
     public String getNickName() {
-        Map<String, Object> profile = getProfile();
-        return (String) profile.get("nickname");
+        return (String) getProfile().get("nickname");
     }
 
     @Override
     public Gender getGender() {
-        Map<String, Object> kakaoAccount = getKakaoAccount();
-        String gender = (String) kakaoAccount.get("gender");
+        String gender = (String) getKakaoAccount().get("gender");
 
         if (gender.equals("male")) {
             return Gender.MAN;
         } else {
             return Gender.WOMAN;
         }
+    }
+
+    public Map<String, Object> getKakaoAccount(){
+        return(Map<String, Object>) attributes.get("kakao_account");
+    }
+
+    public Map<String, Object> getProfile(){
+        return (Map<String, Object>) getKakaoAccount().get("profile");
     }
 }


### PR DESCRIPTION
1. Oauth 로그인 인증 시 첫 로그인은 잘 되나, 두 번째 로그인 시   lazyinitializationexception 이 뜨는 오류 발생 
-> UserRepository NamingQuery 에서 Querydsl을 사용한 UserRepositoryImpl 에서 findByEmail 생성  user 조회 시 user_profile도 fetch join  한방쿼리로 가져옴
2. UserRepositoryCustom, UserRepositoryImpl 생성
3. KakaoUserInfo Class 간결한 코드로 변경