### PR TITLE
Feat : [Add] Oauth kakao login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 //    implementation 'org.springframework.boot:spring-boot-configuration-processor'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
             'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
     implementation 'com.querydsl:querydsl-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+//    implementation 'org.springframework.boot:spring-boot-configuration-processor'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
             'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
     implementation 'com.querydsl:querydsl-jpa'

--- a/src/main/java/com/bob/mate/domain/user/controller/OauthController.java
+++ b/src/main/java/com/bob/mate/domain/user/controller/OauthController.java
@@ -20,6 +20,7 @@ public class OauthController {
     @GetMapping("/login/oauth/{provider}")
     public ResponseEntity<LoginResponse> login(@PathVariable String provider, @RequestParam String code) {
         log.info("In OauthController");
+        log.info("code = {}", code);
         LoginResponse loginResponse = oauthService.login(provider, code);
         return ResponseEntity.ok().body(loginResponse);
     }

--- a/src/main/java/com/bob/mate/domain/user/controller/OauthController.java
+++ b/src/main/java/com/bob/mate/domain/user/controller/OauthController.java
@@ -1,0 +1,26 @@
+package com.bob.mate.domain.user.controller;
+
+import com.bob.mate.domain.user.dto.LoginResponse;
+import com.bob.mate.domain.user.service.OauthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@Slf4j
+@RestController
+public class OauthController {
+
+    private final OauthService oauthService;
+
+    @GetMapping("/login/oauth/{provider}")
+    public ResponseEntity<LoginResponse> login(@PathVariable String provider, @RequestParam String code) {
+        log.info("In OauthController");
+        LoginResponse loginResponse = oauthService.login(provider, code);
+        return ResponseEntity.ok().body(loginResponse);
+    }
+}

--- a/src/main/java/com/bob/mate/domain/user/controller/OauthController.java
+++ b/src/main/java/com/bob/mate/domain/user/controller/OauthController.java
@@ -17,11 +17,16 @@ public class OauthController {
 
     private final OauthService oauthService;
 
+    /**
+     * OAuth 로그인 시 인증 코드를 넘겨받은 후 첫 로그인 시 회원가입
+     */
     @GetMapping("/login/oauth/{provider}")
     public ResponseEntity<LoginResponse> login(@PathVariable String provider, @RequestParam String code) {
         log.info("In OauthController");
         log.info("code = {}", code);
         LoginResponse loginResponse = oauthService.login(provider, code);
+        log.info("loginResponse = {}", loginResponse.getAccessToken());
+
         return ResponseEntity.ok().body(loginResponse);
     }
 }

--- a/src/main/java/com/bob/mate/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/bob/mate/domain/user/dto/LoginResponse.java
@@ -1,0 +1,4 @@
+package com.bob.mate.domain.user.dto;
+
+public class LoginResponse {
+}

--- a/src/main/java/com/bob/mate/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/bob/mate/domain/user/dto/LoginResponse.java
@@ -1,4 +1,31 @@
 package com.bob.mate.domain.user.dto;
 
+import com.bob.mate.domain.user.entity.Role;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class LoginResponse {
+    private Long id;
+    private String name;
+    private String email;
+    private String imageUrl;
+    private Role role;
+    private String tokenType;
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public LoginResponse(Long id, String name, String email, String imageUrl, Role role, String tokenType, String accessToken, String refreshToken) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.imageUrl = imageUrl;
+        this.role = role;
+        this.tokenType = tokenType;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/bob/mate/domain/user/dto/OauthTokenResponse.java
+++ b/src/main/java/com/bob/mate/domain/user/dto/OauthTokenResponse.java
@@ -1,0 +1,26 @@
+package com.bob.mate.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OauthTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    private String scope;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @Builder
+    public OauthTokenResponse(String accessToken, String scope, String tokenType) {
+        this.accessToken = accessToken;
+        this.scope = scope;
+        this.tokenType = tokenType;
+    }
+}

--- a/src/main/java/com/bob/mate/domain/user/entity/User.java
+++ b/src/main/java/com/bob/mate/domain/user/entity/User.java
@@ -61,9 +61,9 @@ public class User implements Auditable {
     /**
      * 생성 메서드
      */
-    public static User createUser(String email,String nickName, Gender gender, String provider, String providerId){
+    public static User createUser(String email,String nickName, Gender gender, String provider, String providerId,String imageUrl){
 
-        UserProfile profile = UserProfile.createProfile(nickName,gender,provider, providerId);
+        UserProfile profile = UserProfile.createProfile(nickName,gender,provider, providerId,imageUrl);
 
         User user = User.builder()
                 .email(email)

--- a/src/main/java/com/bob/mate/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/bob/mate/domain/user/entity/UserProfile.java
@@ -44,10 +44,12 @@ public class UserProfile {
     private String provider;
     private String providerId;
 
+    private String imageUrl;
+
 
 
     @Builder
-    public UserProfile(String nickName, Address address, String phoneNumber, Gender gender, Integer age, String provider, String providerId) {
+    public UserProfile(String nickName, Address address, String phoneNumber, Gender gender, Integer age, String provider, String providerId, String imageUrl) {
         this.nickName = nickName;
         this.address = address;
         this.phoneNumber = phoneNumber;
@@ -55,15 +57,17 @@ public class UserProfile {
         this.age = age;
         this.provider = provider;
         this.providerId = providerId;
+        this.imageUrl = imageUrl;
     }
 
     /**
      * 생성 메서드
      */
-    public static UserProfile createProfile(String nickName, Gender gender,String provider,String providerId) {
+    public static UserProfile createProfile(String nickName, Gender gender,String provider,String providerId,String imageUrl) {
         return UserProfile.builder()
                 .nickName(nickName)
                 .gender(gender)
+                .imageUrl(imageUrl)
                 .provider(provider)
                 .providerId(providerId)
                 .build();

--- a/src/main/java/com/bob/mate/domain/user/service/OauthService.java
+++ b/src/main/java/com/bob/mate/domain/user/service/OauthService.java
@@ -2,37 +2,73 @@ package com.bob.mate.domain.user.service;
 
 import com.bob.mate.domain.user.dto.LoginResponse;
 import com.bob.mate.domain.user.dto.OauthTokenResponse;
+import com.bob.mate.domain.user.entity.Gender;
+import com.bob.mate.domain.user.entity.User;
+import com.bob.mate.domain.user.repository.UserRepository;
+import com.bob.mate.global.config.provider.KakaoUserInfo;
+import com.bob.mate.global.config.provider.Oauth2UserInfo;
+import com.bob.mate.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
 public class OauthService {
 
     private final InMemoryClientRegistrationRepository inMemoryRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
 
+    @Transactional
     public LoginResponse login(String providerName, String code) {
+
+        log.info("in OauthService");
         ClientRegistration provider = inMemoryRepository.findByRegistrationId(providerName);
+        log.info("provider.getClientId = {}", provider.getClientId());
         OauthTokenResponse tokenResponse = getToken(code, provider);
-        return null;
+        log.info("tokenResponse = {}", tokenResponse.getAccessToken());
+        User user = getUserProfile(providerName,tokenResponse,provider);
+
+        String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(user.getId()));
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+
+        return LoginResponse.builder()
+                .id(user.getId())
+                .name(user.getUserProfile().getNickName())
+                .email(user.getEmail())
+                .imageUrl(user.getUserProfile().getImageUrl())
+                .role(user.getRole())
+                .tokenType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
 
     private OauthTokenResponse getToken(String code, ClientRegistration provider) {
+        log.info("OauthService.getToken In");
+        log.info("provider.TokenUri = {}" , provider.getProviderDetails().getTokenUri());
         return WebClient.create()
                 .post()
                 .uri(provider.getProviderDetails().getTokenUri())
                 .headers(header -> {
                     header.setBasicAuth(provider.getClientId(), provider.getClientSecret());
+                    log.info("getClientSecret = {}", provider.getClientSecret());
                     header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
                     header.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
                     header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
@@ -45,11 +81,52 @@ public class OauthService {
 
 
     private MultiValueMap<String, String> tokenRequest(String code, ClientRegistration provider) {
+        log.info("tokenRequest In");
         MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
         formData.add("code", code);
         formData.add("grant_type", "authorization_code");
         formData.add("redirect_uri", provider.getRedirectUri());
         return formData;
+    }
+
+    @Transactional
+    private User getUserProfile(String providerName, OauthTokenResponse tokenResponse, ClientRegistration provider) {
+        Map<String, Object> userAttributes = getUserAttributes(provider, tokenResponse);
+        Oauth2UserInfo oauth2UserInfo = null;
+        if (providerName.equals("kakao")) {
+            log.info("카카오 로그인 요청");
+            oauth2UserInfo = new KakaoUserInfo(userAttributes);
+        } else {
+            log.info("허용되지 않은 접근 입니다.");
+        }
+
+        String provide = oauth2UserInfo.getProvider();
+        String providerId = oauth2UserInfo.getProviderId();
+        String nickName = oauth2UserInfo.getNickName();
+        String email = oauth2UserInfo.getEmail();
+        Gender gender = oauth2UserInfo.getGender();
+        String imageUrl = oauth2UserInfo.getImageUrl();
+
+        User userEntity = userRepository.findByEmail(email);
+
+        log.info("userEmail = {}", userEntity);
+        if (userEntity == null) {
+            userEntity = User.createUser(email, nickName, gender, provide, providerId,imageUrl);
+            userRepository.save(userEntity);
+
+            log.info("userEntity = {}", userEntity);
+        }
+        return userEntity;
+    }
+
+    private Map<String, Object> getUserAttributes(ClientRegistration provider, OauthTokenResponse tokenResponse) {
+        return WebClient.create()
+                .get()
+                .uri(provider.getProviderDetails().getUserInfoEndpoint().getUri())
+                .headers(header -> header.setBearerAuth(tokenResponse.getAccessToken()))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
     }
 
 }

--- a/src/main/java/com/bob/mate/domain/user/service/OauthService.java
+++ b/src/main/java/com/bob/mate/domain/user/service/OauthService.java
@@ -1,0 +1,55 @@
+package com.bob.mate.domain.user.service;
+
+import com.bob.mate.domain.user.dto.LoginResponse;
+import com.bob.mate.domain.user.dto.OauthTokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class OauthService {
+
+    private final InMemoryClientRegistrationRepository inMemoryRepository;
+
+
+    public LoginResponse login(String providerName, String code) {
+        ClientRegistration provider = inMemoryRepository.findByRegistrationId(providerName);
+        OauthTokenResponse tokenResponse = getToken(code, provider);
+        return null;
+    }
+
+    private OauthTokenResponse getToken(String code, ClientRegistration provider) {
+        return WebClient.create()
+                .post()
+                .uri(provider.getProviderDetails().getTokenUri())
+                .headers(header -> {
+                    header.setBasicAuth(provider.getClientId(), provider.getClientSecret());
+                    header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    header.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+                    header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+                })
+                .bodyValue(tokenRequest(code, provider))
+                .retrieve()
+                .bodyToMono(OauthTokenResponse.class)
+                .block();
+    }
+
+
+    private MultiValueMap<String, String> tokenRequest(String code, ClientRegistration provider) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("code", code);
+        formData.add("grant_type", "authorization_code");
+        formData.add("redirect_uri", provider.getRedirectUri());
+        return formData;
+    }
+
+}

--- a/src/main/java/com/bob/mate/global/config/CorsConfig.java
+++ b/src/main/java/com/bob/mate/global/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.bob.mate.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("*"); // e.g. http://domain1.com
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        source.registerCorsConfiguration("/api/**", config);
+        return new CorsFilter(source);
+    }
+
+}

--- a/src/main/java/com/bob/mate/global/config/CorsConfig.java
+++ b/src/main/java/com/bob/mate/global/config/CorsConfig.java
@@ -3,23 +3,26 @@ package com.bob.mate.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 public class CorsConfig {
 
+    /**
+     CORS 허용 적용
+     */
     @Bean
-    public CorsFilter corsFilter() {
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        CorsConfiguration config = new CorsConfiguration();
-        config.setAllowCredentials(true);
-        config.addAllowedOrigin("*"); // e.g. http://domain1.com
-        config.addAllowedHeader("*");
-        config.addAllowedMethod("*");
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
 
-        source.registerCorsConfiguration("/api/**", config);
-        return new CorsFilter(source);
+        configuration.addAllowedOrigin("*");
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
 }

--- a/src/main/java/com/bob/mate/global/config/PrincipalOauth2UserService.java
+++ b/src/main/java/com/bob/mate/global/config/PrincipalOauth2UserService.java
@@ -49,12 +49,13 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
         String nickName = oauth2UserInfo.getNickName();
         String email = oauth2UserInfo.getEmail();
         Gender gender = oauth2UserInfo.getGender();
+        String imageUrl = oauth2UserInfo.getImageUrl();
 
         User userEntity = userRepository.findByEmail(email);
 
         log.info("userEmail = {}", userEntity);
         if (userEntity == null) {
-            userEntity = User.createUser(email, nickName, gender, provider, providerId);
+            userEntity = User.createUser(email, nickName, gender, provider, providerId, imageUrl);
             userRepository.save(userEntity);
 
             log.info("userEntity = {}", userEntity);

--- a/src/main/java/com/bob/mate/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/bob/mate/global/config/WebSecurityConfig.java
@@ -24,15 +24,15 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .formLogin()
                 .disable()
-                .addFilter(corsConfig.corsFilter())
+                .cors().configurationSource(corsConfig.corsConfigurationSource())
+                .and()
 //                .authorizeRequests().antMatchers("/token/**").permitAll()
 //                .and()
 //                .oauth2Login().loginPage("/token/expired")
 //                        .successHandler()
                 .oauth2Login()
                 .userInfoEndpoint()
-                .userService(principalOauth2UserService)
-                .and();
+                .userService(principalOauth2UserService);
 //                .successHandler();
 
 //        http

--- a/src/main/java/com/bob/mate/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/bob/mate/global/config/WebSecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
 
 
 @Configuration
@@ -16,31 +17,27 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable();
-
-//        http
-//                .authorizeRequests()
-//                .anyRequest().permitAll()
+        http.httpBasic().disable()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .formLogin()
+                .disable()
+//                .authorizeRequests().antMatchers("/token/**").permitAll()
 //                .and()
-//                .formLogin()
-//                .loginPage("/user/login")
-//                .loginProcessingUrl("/user/login") //login 주소가 호출이 되면 시큐리티가 낚아채 준다.
-//                .defaultSuccessUrl("/")
-//                .permitAll()
-//                .and()
-//                .logout()
-//                .permitAll();
-        http
+//                .oauth2Login().loginPage("/token/expired")
+//                        .successHandler()
                 .oauth2Login()
                 .userInfoEndpoint()
-                .userService(principalOauth2UserService);
+                .userService(principalOauth2UserService)
+                .and();
+//                .successHandler();
 
-//    }
-//
-//    @Bean
-//    @Override
-//    public AuthenticationManager authenticationManagerBean() throws Exception {
-//        return super.authenticationManagerBean();
+//        http
+//                .oauth2Login()
+//                .userInfoEndpoint()
+//                .userService(principalOauth2UserService);
+
     }
 
 

--- a/src/main/java/com/bob/mate/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/bob/mate/global/config/WebSecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final PrincipalOauth2UserService principalOauth2UserService;
+    private final CorsConfig corsConfig;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -23,6 +24,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .formLogin()
                 .disable()
+                .addFilter(corsConfig.corsFilter())
 //                .authorizeRequests().antMatchers("/token/**").permitAll()
 //                .and()
 //                .oauth2Login().loginPage("/token/expired")

--- a/src/main/java/com/bob/mate/global/config/provider/KakaoUserInfo.java
+++ b/src/main/java/com/bob/mate/global/config/provider/KakaoUserInfo.java
@@ -48,6 +48,11 @@ public class KakaoUserInfo implements Oauth2UserInfo {
         }
     }
 
+    @Override
+    public String getImageUrl() {
+        return (String)getProfile().get("profile_image_url");
+    }
+
     public Map<String, Object> getKakaoAccount(){
         return(Map<String, Object>) attributes.get("kakao_account");
     }

--- a/src/main/java/com/bob/mate/global/config/provider/Oauth2UserInfo.java
+++ b/src/main/java/com/bob/mate/global/config/provider/Oauth2UserInfo.java
@@ -8,4 +8,5 @@ public interface Oauth2UserInfo {
     String getEmail();
     String getNickName();
     Gender getGender();
+    String getImageUrl();
 }

--- a/src/main/java/com/bob/mate/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/bob/mate/global/jwt/JwtTokenProvider.java
@@ -23,6 +23,9 @@ public class JwtTokenProvider {
     private String secretKey;
 
     public String createAccessToken(String payload) {
+        log.info("createToken In accessToken = {}", accessTokenValidityInMilliseconds);
+        log.info("createToken In refreshToken = {}", refreshTokenValidityInMilliseconds);
+        log.info("createToken In secretKey = {}", secretKey);
         return createToken(payload, accessTokenValidityInMilliseconds);
     }
 
@@ -35,9 +38,10 @@ public class JwtTokenProvider {
 
     public String createToken(String payload, long expireLength) {
         Claims claims = Jwts.claims().setSubject(payload);
+        log.info("claims = {}", claims);
         Date now = new Date();
         Date validity = new Date(now.getTime() + expireLength);
-
+        log.info("validity = {}", validity);
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)

--- a/src/main/java/com/bob/mate/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/bob/mate/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,78 @@
+package com.bob.mate.global.jwt;
+
+import io.jsonwebtoken.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Random;
+
+@Component
+@Slf4j
+public class JwtTokenProvider {
+
+    @Value("${jwt.access-token.expire-length}")
+    private long accessTokenValidityInMilliseconds;
+
+    @Value("${jwt.refresh-token.expire-length}")
+    private long refreshTokenValidityInMilliseconds;
+
+    @Value("${jwt.token.secret-key}")
+    private String secretKey;
+
+    public String createAccessToken(String payload) {
+        return createToken(payload, accessTokenValidityInMilliseconds);
+    }
+
+    public String createRefreshToken() {
+        byte[] array = new byte[7];
+        new Random().nextBytes(array);
+        String generatedString = new String(array, StandardCharsets.UTF_8);
+        return createToken(generatedString, refreshTokenValidityInMilliseconds);
+    }
+
+    public String createToken(String payload, long expireLength) {
+        Claims claims = Jwts.claims().setSubject(payload);
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + expireLength);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(SignatureAlgorithm.HS256,secretKey)
+                .compact();
+    }
+
+    public String getPayload(String token){
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().getSubject();
+        } catch (JwtException e){
+            throw new RuntimeException("유효하지 않은 토큰 입니다");
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jws<Claims> claimsJws = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return !claimsJws.getBody().getExpiration().before(new Date());
+        } catch (JwtException | IllegalArgumentException exception) {
+            return false;
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
1. 프론트에서 카카오 로그인 시 code 반환 후 Get으로 code를 OauthController 로 반환 -> OauthServie 에서 Controller 에서 받은 code 로 Oauth 서버에 토큰을 post 요청 (WebFlux) -> 받아온 토큰으로 회원 프로필 조회 후 회원가입 이미 회원가입이 되어 있다면, 조회 한 entity 반환 -> Access Token, Refresh Token 생성 후 프론트로 반환
2. CorsConfig 생성
3. 시큐리티 관련 클래스는 추후에 삭제 예정
4. 원래는 Refresh Token을 Redis에 저장해야 하나 일단 Refresh token을 Redis에 저장하지않고 발급만 하겠습니다(Redis 공부해야함)
5. Build.gradle WebFlux 의존성 추가 
6. Access Token Expire length  = 30분, Refresh Token Expire length = 2주일 설정 