### PR TITLE
Refactor : User 엔티티 CreateUser 생성 메서드 기본이미지 파일 이름 추가

### DIFF
--- a/src/main/java/com/bob/mate/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/bob/mate/domain/user/dto/LoginResponse.java
@@ -1,5 +1,6 @@
 package com.bob.mate.domain.user.dto;
 
+import com.bob.mate.domain.user.entity.Gender;
 import com.bob.mate.domain.user.entity.Role;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LoginResponse {
     private Long id;
-    private String name;
+    private String nickName;
     private String email;
     private String imageUrl;
     private Role role;
@@ -21,7 +22,7 @@ public class LoginResponse {
     @Builder
     public LoginResponse(Long id, String name, String email, String imageUrl, Role role, String tokenType, String accessToken, String refreshToken, boolean profileSaveUser) {
         this.id = id;
-        this.name = name;
+        this.nickName = name;
         this.email = email;
         this.imageUrl = imageUrl;
         this.role = role;

--- a/src/main/java/com/bob/mate/domain/user/entity/Address.java
+++ b/src/main/java/com/bob/mate/domain/user/entity/Address.java
@@ -16,3 +16,4 @@ public class Address {
     private String street;
     private String zipcode;
 }
+// city = "서울시" street = "수정구" zipcode= "복정동 929-1 B02호"

--- a/src/main/java/com/bob/mate/domain/user/entity/Address.java
+++ b/src/main/java/com/bob/mate/domain/user/entity/Address.java
@@ -16,4 +16,3 @@ public class Address {
     private String street;
     private String zipcode;
 }
-// city = "서울시" street = "수정구" zipcode= "복정동 929-1 B02호"

--- a/src/main/java/com/bob/mate/domain/user/entity/User.java
+++ b/src/main/java/com/bob/mate/domain/user/entity/User.java
@@ -60,7 +60,9 @@ public class User implements Auditable {
     /**
      * 생성 메서드
      */
-    public static User createUser(String email,String nickName, Gender gender, String provider, String providerId,String imageUrl){
+    public static User createUser(String email,String nickName, Gender gender, String provider, String providerId){
+
+        final String imageUrl = "af766592-38bc-4d1f-9cf7-663ecf43b82213.png";
 
         UserProfile profile = UserProfile.createProfile(nickName,gender,provider, providerId);
         UploadFile uploadFile = UploadFile.createUploadFile(imageUrl);

--- a/src/main/java/com/bob/mate/domain/user/oauth/OauthAttributes.java
+++ b/src/main/java/com/bob/mate/domain/user/oauth/OauthAttributes.java
@@ -17,8 +17,7 @@ public enum OauthAttributes {
                     kakaoUserInfo.getNickName(),
                     kakaoUserInfo.getGender(),
                     kakaoUserInfo.getProvider(),
-                    kakaoUserInfo.getProviderId(),
-                    kakaoUserInfo.getImageUrl()
+                    kakaoUserInfo.getProviderId()
             );
         }
     };


### PR DESCRIPTION
-  `kakao` 로그인 시 `imgurl` 받아오는 로직 삭제하고 어쩔수없이 `User.createUser` 메소드에서 약간의 ~~하드코딩~~이 되어있습니다.. 😢 
- 배포 서버에서도 저거랑 같은 파일 이름으로 도지 이미지 넣어야 할 것 같습니다.... 
