### PR TITLE
feat: add aws s3 codes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.springframework.boot' version '2.6.2'
+    id 'org.springframework.boot' version '2.6.4'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
@@ -54,10 +54,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.springframework.boot:spring-boot-devtools'
 
     implementation "io.springfox:springfox-boot-starter:3.0.0"
     implementation "io.springfox:springfox-swagger-ui:3.0.0"
+
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.6.RELEASE'
 }
 
 test {

--- a/src/main/java/com/bob/mate/domain/aws/controller/S3Controller.java
+++ b/src/main/java/com/bob/mate/domain/aws/controller/S3Controller.java
@@ -1,0 +1,22 @@
+package com.bob.mate.domain.aws.controller;
+
+import com.bob.mate.domain.aws.service.S3Service;
+import com.bob.mate.global.dto.CustomResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/aws-s3")
+@RequiredArgsConstructor
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    @PostMapping("/upload")
+    public CustomResponse upload(@RequestParam("image")MultipartFile file) throws IOException {
+        return s3Service.upload(file);
+    }
+}

--- a/src/main/java/com/bob/mate/domain/aws/service/S3Service.java
+++ b/src/main/java/com/bob/mate/domain/aws/service/S3Service.java
@@ -1,0 +1,33 @@
+package com.bob.mate.domain.aws.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.bob.mate.global.dto.CustomResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class S3Service {
+
+    public static String CLOUD_FRONT_DOMAIN_NAME = "d3afymv2nzz1pw.cloudfront.net";
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    public String bucket;
+
+    public CustomResponse upload(MultipartFile file) throws IOException {
+        String fileName = file.getOriginalFilename();
+
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), null)
+                .withCannedAcl(CannedAccessControlList.BucketOwnerRead));
+
+        return new CustomResponse("https://" + CLOUD_FRONT_DOMAIN_NAME + "/" + fileName + " 로 업로드 되었습니다.");
+    }
+}

--- a/src/main/java/com/bob/mate/domain/aws/service/S3Service.java
+++ b/src/main/java/com/bob/mate/domain/aws/service/S3Service.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -23,7 +24,7 @@ public class S3Service {
     public String bucket;
 
     public CustomResponse upload(MultipartFile file) throws IOException {
-        String fileName = file.getOriginalFilename();
+        String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
 
         amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), null)
                 .withCannedAcl(CannedAccessControlList.BucketOwnerRead));

--- a/src/main/java/com/bob/mate/global/config/aws/AmazonS3Config.java
+++ b/src/main/java/com/bob/mate/global/config/aws/AmazonS3Config.java
@@ -1,0 +1,31 @@
+package com.bob.mate.global.config.aws;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AmazonS3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -1,0 +1,11 @@
+cloud:
+  aws:
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY}
+      secretKey: ${AWS_SECRET_KEY}
+    s3:
+      bucket: ${AWS_S3_BUCKET_NAME}
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 spring:
   profiles:
-    active: local  #배포 서버에서는 삭제
-    include: oauth-local #배포 서버 oauth 로 변경
+    include: oauth, aws
   datasource:
     url: ${DATABASE_URL}
     username: ${POSTGRES_USERNAME}
@@ -25,4 +24,4 @@ spring:
     port: ${REDIS_PORT}
 
 file:
-  dir: /Users/gimdohun/Desktop/myProject/uploadFile/
+  dir: ${FILE_DIR}


### PR DESCRIPTION
S3 관련 코드를 업로드하였습니다.

1. 실행할때 aws 관련해서 에러 로그가 뜹니다. 
그 이유는 gradle 에서 받은 spring-cloud-starter-aws 가 S3 뿐만 아니라 
EC2 외 다른 몇가지 (EC2 외에도 다른 몇가지 AWS 서비스들) 관련 라이브러리가 포함되어 있는데 
기본적으로 EC2 인스턴스에 접근하도록 내부 코드가 구성되어 있는거 같습니다.
그래서 아래 블로그 글을 참조해보시고 
서버를 실행할때 VM 옵션 값으로 다음의 값을 붙여놓고 실행해야 합니다.
-Dcom.amazonaws.sdk.disableEc2Metadata=true
[블로그](https://lemontia.tistory.com/1006)

2. S3 에 직접 파일을 접근하거나 업로드 할 수도 있는데
cloudfront 라는 CDN 을 써서 우회 접근하도록 설정했습니다.
이걸 사용한 이유는 아래 링크 블로그를 참조해보시면 좋습니다.
[블로그](https://earth-95.tistory.com/128)

3. 지금 작성한 코드에는 S3 에 파일을 업로드 하는 것만 지정했고
파일을 읽는 것은 프론트엔드 쪽에서 CDN 링크를 통해서 우회접속 하도록 만들었습니다.
이 링크는 연빈님께 따로 말씀드리겠습니다